### PR TITLE
dsch-ad-mapper-eks to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,4 +1,7 @@
 dependencies:
+- name: dsch-ad-mapper-eks
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.6
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote dsch-ad-mapper-eks to version 0.0.6